### PR TITLE
add LINUX_ARM_GNUEABIHF

### DIFF
--- a/TestTone/source/CMakeLists.txt
+++ b/TestTone/source/CMakeLists.txt
@@ -1,0 +1,17 @@
+
+cmake_minimum_required(VERSION 2.8.12)
+
+project(TestTone)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+# define a default build type
+if (NOT CMAKE_BUILD_TYPE)
+  message(STATUS "No build type selected, default to Release")
+  set(CMAKE_BUILD_TYPE "Release")
+endif()
+
+add_executable(TestTonePA19 TestTonePA19.c)
+target_link_libraries(TestTonePA19 -L/usr/lib/x86_64-linux-gnu portaudio m rt asound pthread )
+
+add_executable(TestDevicesPA19 TestDevicesPA19.c)
+target_link_libraries(TestDevicesPA19 -L/usr/lib/x86_64-linux-gnu portaudio rt asound pthread )

--- a/mataa_tools/mataa_audio_info.m
+++ b/mataa_tools/mataa_audio_info.m
@@ -35,7 +35,7 @@ function audioInfo = mataa_audio_info;
 plat = mataa_computer;
 
 switch plat
-    case {'MAC','PCWIN','LINUX_X86-32','LINUX_X86-64','LINUX_PPC'}
+ case {'MAC','PCWIN','LINUX_X86-32','LINUX_X86-64','LINUX_PPC','LINUX_ARM_GNUEABIHF'}
     	if strcmp(plat,'PCWIN')
     		extension = '.exe';
     	else

--- a/mataa_tools/mataa_computer.m
+++ b/mataa_tools/mataa_computer.m
@@ -55,6 +55,8 @@ if (exist('OCTAVE_VERSION','builtin')) % we're running Octave
 			platform = 'LINUX_X86-32';
 		elseif  ~isempty(findstr(platform,'powerpc'))
 			platform = 'LINUX_PPC';
+		elseif  ~isempty(findstr(platform,'gnueabihf'))
+			platform = 'LINUX_ARM_GNUEABIHF';
 		else
 			platform = 'LINUX_UNKNOWN';
 		end

--- a/mataa_tools/mataa_measure_signal_response.m
+++ b/mataa_tools/mataa_measure_signal_response.m
@@ -63,7 +63,7 @@ end
 
 % check computer platform:
 plat = mataa_computer;
-if ( ~strcmp(plat,'MAC') && ~strcmp(plat,'PCWIN') && ~strcmp(plat,'LINUX_X86-32') && ~strcmp(plat,'LINUX_X86-64') && ~strcmp(plat,'LINUX_PPC') )
+if ( ~strcmp(plat,'MAC') && ~strcmp(plat,'PCWIN') && ~strcmp(plat,'LINUX_X86-32') && ~strcmp(plat,'LINUX_X86-64') && ~strcmp(plat,'LINUX_PPC')  && ~strcmp(plat,'LINUX_ARM_GNUEABIHF') )
 	error('mataa_measure_signal_response: Sorry, this computer platform is not (yet) supported by the TestTone program.');
 end
 
@@ -80,6 +80,8 @@ case 'LINUX_X86-32'
 case 'LINUX_X86-64'
     desired_API = 'ALSA';
 case 'LINUX_PPC'
+    desired_API = 'ALSA';
+case 'LINUX_ARM_GNUEABIHF'
     desired_API = 'ALSA';
 end
 if ~strcmp (audioInfo.input.API,desired_API)


### PR DESCRIPTION
Hi,

I have added a new platform LINUX_ARM_GNUEABIHF in order to allow measurements from a raspberry pi3.

For the testtone tool I have added a cmake build script in order to allow recompilation more easily.
usage on linux:

mkdir build
cd build 
cmake ...path_to_mataa
make
 
kind regards
  Frank